### PR TITLE
Persist promotion metadata in PR body This allows assigning multi stage promotion PR to the original PR autheor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
+github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -370,7 +370,7 @@ func CreatePrObject(ghPrClientDetails GhPrClientDetails, newBranchRef string, so
 	newPrBody = fmt.Sprintf("# Promotion Path(%s):\n\n", components)
 
 	keys := make([]int, 0)
-	for k, _ := range newPrMetadata.PreviousPromotionMetadata {
+	for k := range newPrMetadata.PreviousPromotionMetadata {
 		keys = append(keys, k)
 	}
 	sort.Ints(keys)

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -2,14 +2,22 @@ package githubapi
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/google/go-github/v48/github"
 	log "github.com/sirupsen/logrus"
 	prom "github.com/wayfair-incubator/telefonistka/internal/pkg/prometheus"
 )
+
+type promotionInstanceMetaData struct {
+	SourcePath  string   `json:"sourcePath"`
+	TargetPaths []string `json:"targetPaths"`
+}
 
 type GhPrClientDetails struct {
 	Ghclient *github.Client
@@ -24,6 +32,39 @@ type GhPrClientDetails struct {
 	Ref           string
 	PrLogger      *log.Entry
 	Labels        []*github.Label
+	PrMetadata    prMetadata
+}
+
+type prMetadata struct {
+	OriginalPrAuthor          string                            `json:"originalPrAuthor"`
+	OriginalPrNumber          int                               `json:"originalPrNumber"`
+	PreviousPromotionMetadata map[int]promotionInstanceMetaData `json:"previousPromotionPaths"`
+}
+
+func (pm prMetadata) serialize() (string, error) {
+	pmJson, err := json.Marshal(pm)
+	if err != nil {
+		return "", err
+	}
+	// var compressedPmJson []byte
+	// _, err = lz4.CompressBlock(pmJson, compressedPmJson, nil)
+	// if err != nil {
+	// return "", err
+	// }
+	return base64.StdEncoding.EncodeToString(pmJson), nil
+}
+
+func (pm *prMetadata) DeSerialize(s string) error {
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	// _, err = lz4.UncompressBlock(decoded, unCompressedPmJson)
+	// if err != nil {
+	// return err
+	// }
+	err = json.Unmarshal(decoded, pm)
+	return err
 }
 
 func (p GhPrClientDetails) CommentOnPr(commentBody string) error {
@@ -299,15 +340,47 @@ func CreateBranch(ghPrClientDetails GhPrClientDetails, commit *github.Commit, ta
 	return newBranchRef, err
 }
 
-func CreatePrObject(ghPrClientDetails GhPrClientDetails, newBranchRef string, targetPaths []string, componentNames []string, originalPrNumber int, defaultBranch string) (*github.PullRequest, error) {
-	components := strings.Join(componentNames, ",")
-	newPrTitle := fmt.Sprintf("🚀 Promotion: %s ➡️  %s", components, strings.Join(targetPaths, " "))
+func CreatePrObject(ghPrClientDetails GhPrClientDetails, newBranchRef string, sourcePath string, targetPaths []string, componentNames []string, defaultBranch string) (*github.PullRequest, error) {
+	var newPrMetadata prMetadata
 	var newPrBody string
-	if len(targetPaths) == 1 {
-		newPrBody = fmt.Sprintf("Promotion of PR #%v (`%s`) to: `%s`", originalPrNumber, components, targetPaths[0])
+	components := strings.Join(componentNames, ",")
+
+	// newPrMetadata will be serialized and persisted in the PR body for use when the PR is merged
+
+	if ghPrClientDetails.PrMetadata.OriginalPrAuthor != "" {
+		newPrMetadata.OriginalPrAuthor = ghPrClientDetails.PrMetadata.OriginalPrAuthor
 	} else {
-		newPrBody = fmt.Sprintf("Promotion of PR #%v (`%s`) to:\n```\n%s\n```", originalPrNumber, components, strings.Join(targetPaths, "\n"))
+		newPrMetadata.OriginalPrAuthor = ghPrClientDetails.PrAuthor
 	}
+
+	if ghPrClientDetails.PrMetadata.PreviousPromotionMetadata != nil {
+		newPrMetadata.PreviousPromotionMetadata = ghPrClientDetails.PrMetadata.PreviousPromotionMetadata
+	} else {
+		newPrMetadata.PreviousPromotionMetadata = make(map[int]promotionInstanceMetaData)
+	}
+
+	newPrMetadata.PreviousPromotionMetadata[ghPrClientDetails.PrNumber] = promotionInstanceMetaData{
+		TargetPaths: targetPaths,
+		SourcePath:  sourcePath,
+	}
+	// newPrMetadata.PreviousPromotionMetadata[ghPrClientDetails.PrNumber].TargetPaths = targetPaths
+	// newPrMetadata.PreviousPromotionMetadata[ghPrClientDetails.PrNumber].SourcePath = sourcePath
+
+	newPrTitle := fmt.Sprintf("🚀 Promotion: %s ➡️  %s", components, strings.Join(targetPaths, " "))
+	newPrBody = fmt.Sprintf("# Promotion Path(%s):\n\n", components)
+
+	keys := make([]int, 0)
+	for k, _ := range newPrMetadata.PreviousPromotionMetadata {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	for i, k := range keys {
+		newPrBody = newPrBody + fmt.Sprintf("%s↘️  #%d  `%s` ➡️ `%s`\n", strings.Repeat("&nbsp;&nbsp;&nbsp;&nbsp;", i), k, newPrMetadata.PreviousPromotionMetadata[k].SourcePath, newPrMetadata.PreviousPromotionMetadata[k].TargetPaths)
+	}
+
+	prMetadataString, _ := newPrMetadata.serialize()
+
+	newPrBody = newPrBody + "\n<!--|Telefonistka data, do not delete|" + prMetadataString + "|-->"
 
 	newPrConfig := &github.NewPullRequest{
 		Body:  github.String(newPrBody),
@@ -334,13 +407,13 @@ func CreatePrObject(ghPrClientDetails GhPrClientDetails, newBranchRef string, ta
 		ghPrClientDetails.PrLogger.Debugf("PR %v labeled\n%+v", pull.Number, prLables)
 	}
 
-	_, resp, err = ghPrClientDetails.Ghclient.Issues.AddAssignees(ghPrClientDetails.Ctx, ghPrClientDetails.Owner, ghPrClientDetails.Repo, *pull.Number, []string{ghPrClientDetails.PrAuthor})
+	_, resp, err = ghPrClientDetails.Ghclient.Issues.AddAssignees(ghPrClientDetails.Ctx, ghPrClientDetails.Owner, ghPrClientDetails.Repo, *pull.Number, []string{newPrMetadata.OriginalPrAuthor})
 	prom.InstrumentGhCall(resp)
 	if err != nil {
-		ghPrClientDetails.PrLogger.Errorf("Could set %s as assignee on PR,  err=%s", ghPrClientDetails.PrAuthor, err)
+		ghPrClientDetails.PrLogger.Errorf("Could set %s as assignee on PR,  err=%s", newPrMetadata.OriginalPrAuthor, err)
 		return pull, err
 	} else {
-		ghPrClientDetails.PrLogger.Debugf(" %s was set as assignee on PR", ghPrClientDetails.PrAuthor)
+		ghPrClientDetails.PrLogger.Debugf(" %s was set as assignee on PR", newPrMetadata.OriginalPrAuthor)
 	}
 
 	// reviewers := github.ReviewersRequest{

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -192,7 +192,6 @@ func handleMergedPrEvent(ghPrClientDetails githubapi.GhPrClientDetails, prApprov
 	promotions, _ := promotion.GeneratePromotionPlan(ghPrClientDetails, config, defaultBranch)
 	// log.Infof("%+v", promotions)
 	if !config.DryRunMode {
-
 		for _, promotion := range promotions {
 			// TODO this whole part shouldn't be in main, but I need to refactor some circular dep's
 


### PR DESCRIPTION
## Description

closes: https://github.com/wayfair-incubator/telefonistka/issues/19

PR metadata is now saved as comment in PR body on creation, this allows future interactions with PR(on merge) to pull said metadata on act on it.
Currently this is used to assign PR based on **original** PR author and document the promotion "path" in the new PR body:
![image](https://user-images.githubusercontent.com/1616153/219339542-56dc222a-defa-4a83-ab3c-995fd49ac99c.png)




## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
