### PR TITLE
Remove custom committer information to support commig signing:

### DIFF
--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -302,10 +302,6 @@ func CreateSyncCommit(ghPrClientDetails GhPrClientDetails, treeEntries []*github
 		Message: github.String("Syncing from " + sourcePath),
 		Parents: []*github.Commit{parentCommit},
 		Tree:    tree,
-		Author: &github.CommitAuthor{
-			Name:  github.String("Telefonistka GitOps Bot"),
-			Email: github.String("gitops-telefonistka@wayfair.com"), // TODO change these
-		},
 	}
 
 	commit, resp, err := ghPrClientDetails.Ghclient.Git.CreateCommit(ghPrClientDetails.Ctx, ghPrClientDetails.Owner, ghPrClientDetails.Repo, newCommitConfig)


### PR DESCRIPTION
https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification

Signature verification for bots will only work if the request is
verified and authenticated as the GitHub App or bot and contains no
custom author information, custom committer information, and no custom
signature information, such as Commits API.

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
