### PR TITLE
Fix wrong URL for GH enterprise server graphQL endpoint issue

### DIFF
--- a/internal/pkg/githubapi/clients.go
+++ b/internal/pkg/githubapi/clients.go
@@ -98,16 +98,16 @@ func CreateGithubRestClient(githubOauthToken string, githubRestAltURL string, ct
 	return client
 }
 
-func createGithubAppGraphQlClient(githubAppPrivateKeyPath string, githubAppId int64, githubAppInstallationId int64, githubGraphqlAltURL string, githubRestAltURL string, ctx context.Context) *githubv4.Client {
+func createGithubAppGraphQlClient(githubAppPrivateKeyPath string, githubAppId int64, githubAppInstallationId int64, githubGraphqlAltURL string, ctx context.Context) *githubv4.Client {
 	itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport, githubAppId, githubAppInstallationId, githubAppPrivateKeyPath)
 	if err != nil {
 		log.Fatal(err)
 	}
 	var client *githubv4.Client
 
-	if githubRestAltURL != "" {
-		itr.BaseURL = githubRestAltURL
-		client = githubv4.NewEnterpriseClient(githubRestAltURL, &http.Client{Transport: itr})
+	if githubGraphqlAltURL != "" {
+		itr.BaseURL = githubGraphqlAltURL
+		client = githubv4.NewEnterpriseClient(githubGraphqlAltURL, &http.Client{Transport: itr})
 	} else {
 		client = githubv4.NewClient(&http.Client{Transport: itr})
 	}
@@ -157,7 +157,7 @@ func CreateAllClients(ctx context.Context) (*github.Client, *githubv4.Client, *g
 		}
 
 		mainGithubClient = createGithubAppRestClient(githubAppPrivateKeyPath, githubAppId, githubAppInstallationId, githubRestAltURL, ctx)
-		githubGraphQlClient = createGithubAppGraphQlClient(githubAppPrivateKeyPath, githubAppId, githubAppInstallationId, githubGraphqlAltURL, githubRestAltURL, ctx)
+		githubGraphQlClient = createGithubAppGraphQlClient(githubAppPrivateKeyPath, githubAppId, githubAppInstallationId, githubGraphqlAltURL, ctx)
 	} else {
 		mainGithubClient = CreateGithubRestClient(getCrucialEnv("GITHUB_OAUTH_TOKEN"), githubRestAltURL, ctx)
 		githubGraphQlClient = createGithubGraphQlClient(getCrucialEnv("GITHUB_OAUTH_TOKEN"), githubGraphqlAltURL)


### PR DESCRIPTION
## Description

REST API url was used for *enterprise server* graphQL client, which didn't work.
This change fixes that.


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
