### PR TITLE
Promotion dry runs should use PR branch, not the default branch

### DIFF
--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -149,7 +149,7 @@ func HandleEvent(eventType string, payload []byte, ctx context.Context, mainGhCl
 			if err != nil {
 				ghPrClientDetails.PrLogger.Infof("Couldn't get Telefonistka in-repo configuration: %v", err)
 			} else {
-				promotions, _ := GeneratePromotionPlan(ghPrClientDetails, config, defaultBranch)
+				promotions, _ := GeneratePromotionPlan(ghPrClientDetails, config, ghPrClientDetails.Ref)
 				commentPlanInPR(ghPrClientDetails, promotions)
 			}
 		}


### PR DESCRIPTION
## Description

Dry-run are triggered in the PR context and should fetch in-component configuration from the PR branch.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
