### PR TITLE
Support overriding the default template dir

### DIFF
--- a/cmd/telefonistka/event.go
+++ b/cmd/telefonistka/event.go
@@ -48,7 +48,7 @@ func event(eventType string, eventFilePath string) {
 	h, _ := http.NewRequest("POST", "", nil) //nolint:noctx
 	h.Body = io.NopCloser(bytes.NewReader(payload))
 	h.Header.Set("Content-Type", "application/json")
-	h.Header.Set("X-GitHub-Event", "push")
+	h.Header.Set("X-GitHub-Event", "pull_request")
 
 	mainGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
 	prApproverGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)

--- a/cmd/telefonistka/event.go
+++ b/cmd/telefonistka/event.go
@@ -48,7 +48,7 @@ func event(eventType string, eventFilePath string) {
 	h, _ := http.NewRequest("POST", "", nil) //nolint:noctx
 	h.Body = io.NopCloser(bytes.NewReader(payload))
 	h.Header.Set("Content-Type", "application/json")
-	h.Header.Set("X-GitHub-Event", "pull_request")
+	h.Header.Set("X-GitHub-Event", eventType)
 
 	mainGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
 	prApproverGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)

--- a/cmd/telefonistka/event.go
+++ b/cmd/telefonistka/event.go
@@ -45,13 +45,14 @@ func event(eventType string, eventFilePath string) {
 	// To use the same code path as for Webhook I'm creating an http request with the payload from the file.
 	// This might not be very smart.
 
-	h := http.Request{}
+	h, _ := http.NewRequest("POST", "", nil)
 	h.Body = io.NopCloser(bytes.NewReader(payload))
 	h.Header.Set("Content-Type", "application/json")
+	h.Header.Set("X-GitHub-Event", "push")
 
 	mainGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
 	prApproverGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
-	githubapi.HandleEvent(&h, ctx, mainGhClientCache, prApproverGhClientCache, nil)
+	githubapi.HandleEvent(h, ctx, mainGhClientCache, prApproverGhClientCache, nil)
 }
 
 func getEnv(key, fallback string) string {

--- a/cmd/telefonistka/event.go
+++ b/cmd/telefonistka/event.go
@@ -45,7 +45,7 @@ func event(eventType string, eventFilePath string) {
 	// To use the same code path as for Webhook I'm creating an http request with the payload from the file.
 	// This might not be very smart.
 
-	h, _ := http.NewRequest("POST", "", nil)
+	h, _ := http.NewRequest("POST", "", nil) //nolint:noctx
 	h.Body = io.NopCloser(bytes.NewReader(payload))
 	h.Header.Set("Content-Type", "application/json")
 	h.Header.Set("X-GitHub-Event", "push")

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,6 +75,8 @@ Environment variables for the webhook process:
 
 `GITHUB_APP_ID` Application ID for Github applications style of deployments, available in the Github Application setting page.
 
+`TEMPLATES_PATH` Telefonistka uses Go templates to format GitHub PR comments, the variable override the default templates path("templates/"), useful for environments where the container workdir is overridden(like GitHub Actions) or when custom templates are desired.
+
 Behavior of the bot is configured by YAML files **in the target repo**:
 
 ## Repo Configuration

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -247,7 +247,7 @@ func handleCommentPrEvent(ghPrClientDetails GhPrClientDetails, ce *github.IssueC
 
 func commentPlanInPR(ghPrClientDetails GhPrClientDetails, promotions map[string]PromotionInstance) {
 	var templateOutput bytes.Buffer
-	dryRunMsgTemplate, err := template.New("dryRunMsg").ParseFiles("templates/dry-run-pr-comment.gotmpl")
+	dryRunMsgTemplate, err := template.New("dryRunMsg").ParseFiles(getEnv("TEMPLATES_PATH", "templates/") + "dry-run-pr-comment.gotmpl")
 	if err != nil {
 		ghPrClientDetails.PrLogger.Errorf("Failed to parse template: err=%v", err)
 	}

--- a/internal/pkg/githubapi/promotion.go
+++ b/internal/pkg/githubapi/promotion.go
@@ -74,7 +74,7 @@ func DetectDrift(ghPrClientDetails GhPrClientDetails) error {
 	}
 	if len(diffOutputMap) != 0 {
 		var templateOutput bytes.Buffer
-		driftMsgTemplate, err := template.New("driftMsg").ParseFiles("templates/drift-pr-comment.gotmpl")
+		driftMsgTemplate, err := template.New("driftMsg").ParseFiles(getEnv("TEMPLATES_PATH", "templates/") + "drift-pr-comment.gotmpl")
 		if err != nil {
 			ghPrClientDetails.PrLogger.Errorf("Failed to parse template: err=%v", err)
 			return err


### PR DESCRIPTION
## Description

GH action doesn't support overriding the workdir https://github.com/actions/runner/issues/878
Template are set as relative dir the allow easy local testing.

This PR will allow overrding the template dir to support GitHub action.


closes https://github.com/wayfair-incubator/telefonistka/issues/97

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
