### PR TITLE
Dry-run "show promotion plan" should be based on the configuration in the PR

### DIFF
--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -110,7 +110,7 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 		if err != nil {
 			ghPrClientDetails.PrLogger.Infof("Couldn't get Telefonistka in-repo configuration: %v", err)
 		} else {
-			promotions, _ := GeneratePromotionPlan(ghPrClientDetails, config, defaultBranch)
+			promotions, _ := GeneratePromotionPlan(ghPrClientDetails, config, *eventPayload.PullRequest.Head.Ref)
 			commentPlanInPR(ghPrClientDetails, promotions)
 		}
 	}


### PR DESCRIPTION
## Description
When a PR is labled with `show-plan` Telefonistka generate a plan and post in the PR.
At the moment the plan is generated based on configuration files in the main branch, this doesn't make a lot of sense.
This change will make telefonistka user the files in PR branch.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
