### PR TITLE
reenable publishing dockerhub images

### DIFF
--- a/.github/workflows/docker-publish-on-comment.yml
+++ b/.github/workflows/docker-publish-on-comment.yml
@@ -58,6 +58,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log into Docker Hub registry ${{ env.REGISTRY }}
+        uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -70,6 +75,7 @@ jobs:
           context: git
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            wayfaiross/telefonistka
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker-publish-on-comment.yml
+++ b/.github/workflows/docker-publish-on-comment.yml
@@ -75,7 +75,7 @@ jobs:
           context: git
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            wayfaiross/telefonistka
+            odedbenozer/telefonistka
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,7 +78,7 @@ jobs:
         with: 
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            wayfaiross/telefonistka
+            odedbenozer/telefonistka
 
 
       # Build and push Docker image with Buildx (don't push on PR)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log into Docker Hub registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -72,6 +78,7 @@ jobs:
         with: 
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            wayfaiross/telefonistka
 
 
       # Build and push Docker image with Buildx (don't push on PR)


### PR DESCRIPTION
- Revert "Disable Publishing of images to DockerHub until token issue is addressed (#158)"
- Move to personal GH org until the WayfairOSS thing is sorted out

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
