### PR TITLE
Add additional docker image that is based on alpine

### DIFF
--- a/.github/workflows/docker-publish-on-comment.yml
+++ b/.github/workflows/docker-publish-on-comment.yml
@@ -58,6 +58,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log into Docker Hub registry ${{ env.REGISTRY }}
+        uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -70,6 +75,7 @@ jobs:
           context: git
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            odedbenozer/telefonistka
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker-publish-on-comment.yml
+++ b/.github/workflows/docker-publish-on-comment.yml
@@ -9,11 +9,6 @@ on:
   issue_comment:
     types: [created]
 
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
 
 
 jobs:
@@ -51,14 +46,15 @@ jobs:
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
-      - name: Log into GH registry ${{ env.REGISTRY }}
+      - name: Log into GH registry (ghcr.io)
         uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log into Docker Hub registry ${{ env.REGISTRY }}
+      - name: Log into Docker Hub registry 
+        if: secrets.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -75,7 +71,6 @@ jobs:
           context: git
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            odedbenozer/telefonistka
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker-publish-on-comment.yml
+++ b/.github/workflows/docker-publish-on-comment.yml
@@ -10,6 +10,10 @@ on:
     types: [created]
 
 
+env:
+  DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+  REGISTRY: ${{ vars.REGISTRY }}
 
 jobs:
   build:
@@ -54,10 +58,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into Docker Hub registry 
-        if: secrets.DOCKERHUB_TOKEN != ''
+        if: env.DOCKERHUB_USERNAME != '' 
         uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log into Docker Hub registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -72,6 +78,7 @@ jobs:
         with: 
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            odedbenozer/telefonistka
 
 
       # Build and push Docker image with Buildx (don't push on PR)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+  REGISTRY: ${{ vars.REGISTRY }}
 
 jobs:
   build:
@@ -56,10 +60,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into Docker Hub registry 
-        if: github.event_name != 'pull_request' && secrets.DOCKERHUB_TOKEN != ''
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,12 +15,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
-
 
 jobs:
   build:
@@ -53,16 +47,16 @@ jobs:
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
-      - name: Log into GH registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+      - name: Log into GH registry (ghcr.io)
+        if: github.event_name != 'pull_request'  
         uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log into Docker Hub registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+      - name: Log into Docker Hub registry 
+        if: github.event_name != 'pull_request' && secrets.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -78,7 +72,6 @@ jobs:
         with: 
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            odedbenozer/telefonistka
 
 
       # Build and push Docker image with Buildx (don't push on PR)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ See [here](docs/observability.md)
 * Add a webhook to repo setting (don't forget the `/webhook` path in the URL).
 * Content type needs to be `application/json`, **currently** only PR events are needed
 
+To publish container images from a forked repo set the `IMAGE_NAME` and `REGISTRY` GitHub Action Repository variables to use GitHub packages.
+`REGISTRY` should be `ghcr.io` and `IMAGE_NAME` should match the repository slug, like so:
+like so:
+<img width="785" alt="image" src="https://github.com/commercetools/telefonistka/assets/1616153/2f7201d6-fdb2-4cbf-8705-d6da7f4f6e80">
+
+
+
+
 ## Roadmap
 
 See the [open issues](https://github.com/wayfair-incubator/telefonistka/issues) for a list of proposed features (and known issues).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,7 +65,7 @@ Telefonistka comes in 2 flavors:
 
 * A normal container image, that is built from `scratch` and contains only a telefonistka binary and CA certificates.
   This image is preferred and meant to be used in a production environment.
-* A container image that is built on `alpine` and contains the full alpine base OS.
+* A container image that is built on `alpine` and contains the full alpine base OS. Denoted by the `alpine-` prefix.
   This image is meant for development and debugging purposes.
   And in rare cases when it is used in CI and requires shell variable expansion.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,6 +59,16 @@ The Github side of the configuration can be done via a creation of an GitHub App
   * Ensure the service account has the relevant permission on the repo.
   * Add `telefonistka.yaml` to repo root.
 
+## Images
+
+Telefonistka comes in 2 flavors:
+
+* A normal container image, that is built from `scratch` and contains only a telefonistka binary and CA certificates.
+  This image is preferred and meant to be used in a production environment.
+* A container image that is built on `alpine` and contains the full alpine base OS.
+  This image is meant for development and debugging purposes.
+  And in rare cases when it is used in CI and requires shell variable expansion.
+
 ## Server Configuration
 
 Environment variables for the webhook process:


### PR DESCRIPTION
## Description

We are integrating `telefonistka` into CD flow with the `bump-regex` command, but we have trouble executing it in CI, as we want to do some bash variable expansion, but the current container for `telefonistka` is built from scratch, and does not have a shell.

Solution: a separate telefonistka container image that is based on `alpine:latest` instead of `scratch`.
The new image will have a tag `prefix` of `alpine-`:
* `wayfaiross/telefonistka:alpine-vX.Y.Z`
* `wayfaiross/telefonistka:alpine-latest`

Added a new `target` into the existing `Dockerfile`, and added extra steps into `.github/workflows/` to actually build and push the new images.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
