### PR TITLE
 Allow skipping upstream TLS server certificate validation for the webhook proxy functionality

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,6 +109,7 @@ Configuration keys:
 |`dryRunMode`| if true, the bot will just comment the planned promotion on the merged PR|
 |`autoApprovePromotionPrs`| if true the bot will auto-approve all promotion PRs, with the assumption the original PR was peer reviewed and is promoted verbatim. Required additional GH token via APPROVER_GITHUB_OAUTH_TOKEN env variable|
 |`toggleCommitStatus`| Map of strings, allow (non-repo-admin) users to change the [Github commit status](https://docs.github.com/en/rest/commits/statuses) state(from failure to success and back). This can be used to continue promotion of a change that doesn't pass repo checks. the keys are strings commented in the PRs, values are [Github commit status context](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status) to be overridden|
+|`whProxtSkipTLSVerifyUpstream`| This disables upstream TLS server certificate validation for the webhook proxy functionality. Default is `false`. |
 <!-- markdownlint-enable MD033 -->
 
 Example:

--- a/internal/pkg/configuration/config.go
+++ b/internal/pkg/configuration/config.go
@@ -35,11 +35,12 @@ type Config struct {
 	PromotionPaths []PromotionPath `yaml:"promotionPaths"`
 
 	// Generic configuration
-	PromtionPrLables        []string               `yaml:"promtionPRlables"`
-	DryRunMode              bool                   `yaml:"dryRunMode"`
-	AutoApprovePromotionPrs bool                   `yaml:"autoApprovePromotionPrs"`
-	ToggleCommitStatus      map[string]string      `yaml:"toggleCommitStatus"`
-	WebhookEndpointRegexs   []WebhookEndpointRegex `yaml:"webhookEndpointRegexs"`
+	PromtionPrLables             []string               `yaml:"promtionPRlables"`
+	DryRunMode                   bool                   `yaml:"dryRunMode"`
+	AutoApprovePromotionPrs      bool                   `yaml:"autoApprovePromotionPrs"`
+	ToggleCommitStatus           map[string]string      `yaml:"toggleCommitStatus"`
+	WebhookEndpointRegexs        []WebhookEndpointRegex `yaml:"webhookEndpointRegexs"`
+	WhProxtSkipTLSVerifyUpstream bool                   `yaml:"whProxtSkipTLSVerifyUpstream"`
 }
 
 func ParseConfigFromYaml(y string) (*Config, error) {


### PR DESCRIPTION
## Description

 Allow skipping upstream TLS server certificate validation for the webhook proxy functionality
 Use-case: Handeling PKI to allow verification of TLS in in-cluster(k8s) services (https://argocd.argocd.svc.cluster.local) is hard.
 Some services don't provide an easy way to expose both TLS and plaintext endpoint without redirecting the traffic to the TLS endpoint and Webhook payloads are 
 **relitivly** low risk  so skipping TLS verification might make sense for some users.


## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
